### PR TITLE
add options argument to pipeline signature

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,9 +7,9 @@ module.exports = valuePipe
 function valuePipe (fns) {
   if (!fns) throw new TypeError('At least one function is required')
   if (!Array.isArray(fns)) return valuePipe(toArray(arguments))
-  return function valuePipeline (value) {
+  return function valuePipeline (value, options) {
     for (var i = 0; i < fns.length; i++) {
-      value = fns[i](value)
+      value = fns[i](value, options)
     }
     return value
   }


### PR DESCRIPTION
so the signature of a 'pipeline' is now:

```js
(value, options) => nextValue
```

with `options` being passed in to the 'parent pipeline'.

---

the use case is i want to create a value pipeline to transform objects, and these transformers also should receive options that will configure how they transform. i first tried to create the transformers with those options and return a closure, but then this way was easier. not sure if this is a worthwhile api addition here, but using it in [`catstack@v2`](https://github.com/enspiral-root-systems/catstack/tree/v2) for now.